### PR TITLE
Remove the example on how to call the API through PHP

### DIFF
--- a/docs/3.x/querying-the-reporting-api.md
+++ b/docs/3.x/querying-the-reporting-api.md
@@ -5,10 +5,7 @@ next: reporting-api-clients
 ---
 # Querying the Reporting API
 
-This guide explains how to call the Piwik API to request your web analytics data. There are two methods:
-
-- using the standard HTTP API 
-- using Piwik's PHP code directly
+This guide explains how to call the Piwik API to request your web analytics data. 
 
 ## Call the Piwik API using the HTTP API
 
@@ -31,22 +28,6 @@ Here is the output of this code:
 ```html
 {@include escape https://piwik.org/api_rest_call.php}
 ``` 
-
-## Call the Piwik API in PHP
-
-If you want to request data in a PHP script **that is on the same server as Piwik**, you can use this simple technique. This is a more efficient solution as it doesn't require network calls. You directly call the PHP Piwik runtime and get the PHP data structure back.
-
-If you are developing a plugin, you should be using this technique. Please note that including index.php will set the default timezone of the calling code to UTC.
-
-```php
-{@include escape https://raw.github.com/matomo-org/matomo/master/misc/others/api_internal_call.php}
-```
-
-Here is the output of this script:
-
-```xml
-{@include escape http://demo.piwik.org/misc/others/api_internal_call.php}
-```
 
 ## Learn more
 


### PR DESCRIPTION
This is not needed and HTTP should always be recommended. There is not really a performance or resources improvement over going through HTTP. Also the example doesn't work and would need to be updated regularly. None of those methods mentioned there are API and it is only a matter of time until it breaks (it did in the past eg when we added environment etc).