### PR TITLE
Blacklist individual tags, triggers, and variables so they don't appear in the API reference

### DIFF
--- a/generator/ApiClasses/Filter.php
+++ b/generator/ApiClasses/Filter.php
@@ -174,6 +174,21 @@ class Filter extends \Sami\Parser\Filter\DefaultFilter {
         if ($this->isSubclassOf($rc, 'Piwik\Plugin\Visualization')) {
             return true;
         }
+        
+        if (class_exists('Piwik\Plugins\TagManager\Template\Tag\BaseTag') 
+            && $this->isSubclassOf($rc, 'Piwik\Plugins\TagManager\Template\Tag\BaseTag')) {
+            return true;
+        }
+
+        if (class_exists('Piwik\Plugins\TagManager\Template\Trigger\BaseTrigger') 
+            && $this->isSubclassOf($rc, 'Piwik\Plugins\TagManager\Template\Trigger\BaseTrigger')) {
+            return true;
+        }
+
+        if (class_exists('Piwik\Plugins\TagManager\Template\Variable\BaseVariable') 
+            && $this->isSubclassOf($rc, 'Piwik\Plugins\TagManager\Template\Variable\BaseVariable')) {
+            return true;
+        }
 
         $trackingDimensions = array(
             'Piwik\Plugin\Dimension\ActionDimension',


### PR DESCRIPTION
To be merged at the latest once we add Tag Manager as a submodule to prevent each individual tag, variable, and trigger to appear in the list of PHP API classes.