### PR TITLE
require token for webhook

### DIFF
--- a/app/config/app.php
+++ b/app/config/app.php
@@ -16,3 +16,7 @@ if (! defined('LATEST_PIWIK_DOCS_VERSION')) {
 if (! defined('DOCS_DOMAIN')) {
     define('DOCS_DOMAIN', 'developer.matomo.org');
 }
+
+if (! defined('WEBHOOK_TOKEN')) {
+    define('WEBHOOK_TOKEN', '$2y$10$7StRWWP4gYyuhLIOAWD1Cuw.jOsMWuTwi9DTENPUVakrNN4/H31Gq'); // "changeme"
+}

--- a/app/routes/page.php
+++ b/app/routes/page.php
@@ -186,6 +186,12 @@ $app->get('/data/documents', function (Request $request, Response $response, $ar
 });
 
 $app->post('/receive-commit-hook', function (Request $request, Response $response, $args) {
+    $params = $request->getQueryParams();
+    if (empty($params["token"]) || !password_verify($params["token"], WEBHOOK_TOKEN)) {
+        $response->getBody()->write("parameter 'token' missing or incorrect");
+        return $response->withStatus(403);
+    }
+
     system('git pull');
 
     Cache::invalidate();


### PR DESCRIPTION
recreation of 36e65247be01aa69bb267c6f8e5102defbedd24e

Allowing everyone to clear the cache allows to put a huge load on the server. 

Therefore a custom token should be defined in the local.php and the webhook config should be changed to use `/receive-commit-hook?token=thetoken`