### PR TITLE
support api-reference subdirectories

### DIFF
--- a/app/routes/page.php
+++ b/app/routes/page.php
@@ -128,6 +128,15 @@ $app->get('/api-reference/PHP-Piwik-Tracker', function (Request $request, Respon
     return renderGuide($this->get("view"), $response, $request->getUri(), new PhpDoc('PiwikTracker', 'PHP-Piwik-Tracker'), new ApiReferenceCategory());
 });
 
+$app->get('/api-reference/{reference1}/{reference2}', function (Request $request, Response $response, $args) {
+    try {
+        $guide = new ApiReferenceGuide($args["reference1"] . '/' . $args["reference2"]);
+    } catch (DocumentNotExistException $e) {
+        throw new \Slim\Exception\HttpNotFoundException($request);
+    }
+    return renderGuide($this->get("view"), $response, $request->getUri(), $guide, new ApiReferenceCategory());
+});
+
 $app->get('/api-reference/{reference}', function (Request $request, Response $response, $args) {
 
     try {


### PR DESCRIPTION
fixes https://developer.matomo.org/api-reference/tagmanager/javascript-api-reference

I didn't notice this section was added since I last rewrote the routes.