### PR TITLE
remove broken 2.x docs

### DIFF
--- a/docs/2.x/querying-the-reporting-api.md
+++ b/docs/2.x/querying-the-reporting-api.md
@@ -20,33 +20,12 @@ If you want to request data in any language (PHP, Python, Ruby, ASP, C++, Java, 
 If the API call requires the token_auth and the HTTP request is sent over untrusted networks, we highly advise that you use an encrypted request. Otherwise, your token\_auth is exposed to eavesdroppers. This can be done using https instead of http. In the following example, replace the string "http" by "https".
 </div>
 
-You can, for example, get the top 100 search engine keywords used to find your website during the current week. Here is an example in PHP:
-
-```php
-{@include escape https://raw.github.com/matomo-org/matomo/master/misc/others/api_rest_call.php}
-```
-
-Here is the output of this code:
-
-```html
-{@include escape https://piwik.org/api_rest_call.php}
-``` 
-
 ## Call the Piwik API in PHP
 
 If you want to request data in a PHP script **that is on the same server as Piwik**, you can use this simple technique. This is a more efficient solution as it doesn't require network calls. You directly call the PHP Piwik runtime and get the PHP data structure back.
 
 If you are developing a plugin, you should be using this technique. Please note that including index.php will set the default timezone of the calling code to UTC.
 
-```php
-{@include escape https://raw.github.com/matomo-org/matomo/master/misc/others/api_internal_call.php}
-```
-
-Here is the output of this script:
-
-```xml
-{@include escape http://demo.piwik.org/misc/others/api_internal_call.php}
-```
 
 ## Learn more
 


### PR DESCRIPTION
This removes the ugly 

 Warning: file_get_contents(https://raw.github.com/matomo-org/matomo/master/misc/others/api_internal_call.php): failed to open stream: HTTP request failed! HTTP/1.1 404 Not Found in /home/piwik-developer/developer-documentation/app/helpers/Markdown/IncludeFilePostprocessor.php on line 71

warnings on https://developer.matomo.org/2.x/guides/tagmanager/introduction.

While the documentation is outdated anyway, this is an easy fix.