### PR TITLE
Rewrite frontend build guides for Vite

### DIFF
--- a/docs/6.x/asset-pipeline.md
+++ b/docs/6.x/asset-pipeline.md
@@ -13,8 +13,8 @@ Matomo can handle and process many different types of frontend assets, including
 * vanilla CSS
 * LESS
 * vanilla JavaScript
-* ECMAScript (processed by babel)
-* TypeScript (processed by the TypeScript compiler, then babel)
+* ECMAScript (processed by Vite)
+* TypeScript (processed by the TypeScript compiler, then Vite)
 * Vue files (where the specific language is chosen within the file)
 
 ### Vanilla JavaScript, CSS and LESS files
@@ -41,31 +41,26 @@ included like a file you'd specify through [`AssetManager.getJavaScriptFiles`](/
 
 ### Building UMD modules
 
-Matomo uses the [Vue CLI](https://cli.vuejs.org/) tool to bundle advanced assets. There is one global configuration that
-is used for every Matomo plugin.
+Matomo uses [Vite](https://vite.dev/) to bundle advanced assets. There is one global configuration, `vite.config.ts` in
+Matomo's root folder, that is used for every Matomo plugin.
 
-The build process is initiated through the Matomo command `vue:build`. Internally, this invokes the Vue CLI service, which
-in turn, invokes many separate tools that process individual files. These tools are:
+The build process is initiated through the Matomo command `vue:build`. Internally, the command loops over the plugins to
+build and invokes `plugins/CoreVue/scripts/vite-runner.mjs` once per plugin, passing the plugin through the
+`MATOMO_CURRENT_PLUGIN` environment variable. Each plugin's Vue library is therefore built on its own. The tools involved are:
 
-- [the TypeScript compiler](https://www.typescriptlang.org/): used to compile TypeScript and Vue files into ES files. The
-  configuration for this tool is stored in the `tsconfig.json` file in Matomo's root folder. Individual plugins can
-  extend and/or override this file by placing their own `tsconfig.json` in their `vue` folder.
+- [the TypeScript compiler](https://www.typescriptlang.org/): used to type check and to emit declarations into the
+  `@types/<Plugin>` folder. The configuration is stored in the `tsconfig.json` file in Matomo's root folder. Individual
+  plugins can extend and/or override this file by placing their own `tsconfig.json` in their `vue` folder.
+- [Vite](https://vite.dev/): the bundler. It converts ES modules into UMD files that can be loaded directly in the browser.
+  Matomo's `vite.config.ts` keeps `vue`, `tslib` and every other plugin's Vue library external, so that plugin UMD modules
+  can be accessed from other plugins at runtime rather than being bundled into each other.
+- [esbuild](https://esbuild.github.io/) and [terser](https://terser.org/): used by Vite to transform and minify the output.
+  The compile target is set with the `build.target` option in `vite.config.ts`.
 - [ESLint](https://eslint.org/): used to lint our TypeScript, Vue and ES files. Currently we use the
   [https://github.com/airbnb/javascript](Airbnb ESlint ruleset). Base configuration for this tool is stored in the
   `.eslintrc.js` file in Matomo's root folder. Plugins can extend or override this file by placing their own `.eslintrc.js`
-  file in their `vue` folder.
-- [Babel](https://babeljs.io/): used to compile the ES that the TypeScript compiler emits into JavaScript that
-  can be consumed by the browsers we support. Technically, the TypeScript compiler can do this too, but babel is included
-  as well, since it provides some features the TypeScript compiler does not, such as [modern mode](https://cli.vuejs.org/guide/browser-compatibility.html#modern-mode).
-  Babel is also extensible in a way TypeScript is not, so overall it provides more power and possibility.
-  Babel configuration is stored in the `babel.config.js` file.
-- [Webpack](https://webpack.js.org/): the bundler used by Vue CLI, webpack converts ES modules into UMD files that can
-  be loaded directly in the browser. Webpack config is stored in the `vue.config.js` file. Vue CLI uses the [webpack-chain](https://github.com/neutrinojs/webpack-chain)
-  tool to allow users to add custom webpack config. Matomo adds some extra config to make sure plugin UMD modules
-  can be accessed from other plugins at runtime.
-- [browserslist](https://github.com/browserslist/browserslist): this tool is used to specify what browsers we want our
-  compiled JavaScript to be compatible with, and is used by babel to understand which advanced ES features need to be
-  transpiled and which do not. Configuration for this tool is in the `.browserslistrc` file.
+  file in their `vue` folder. Unlike the previous Vue CLI setup, linting is **not** part of `vue:build`; run it separately
+  with `npm run eslint`.
 
 ### UMD Module Dependencies
 
@@ -85,8 +80,8 @@ the UMD modules that get loaded.
 
 Detecting plugin dependencies is done by:
 
-* using a function in the `externals` webpack config. When a request for a plugin UMD is detected,
-  we save it in an array.
+* using the `external` callback in `vite.config.ts`. When a request for a plugin UMD is detected,
+  we save it in a set.
 * Later, after compilation has ended, we output the array to a metadata JSON file (`plugins/MyPlugin/vue/dist/umd.metadata.json`).
 
 Ordering of plugins is done in PluginUmdAssetFetcher.php by:
@@ -96,22 +91,15 @@ Ordering of plugins is done in PluginUmdAssetFetcher.php by:
 
 ### Browser support
 
-As stated above, `browserslist` is used to control what browsers our compiled JavaScript supports. In the `.browserslistrc`
-file we specify some generic parameters, like `> 0.05%` (we want to support browsers with an overall usage of over 0.05%) and
-`last 2 versions` (we want to support the last two versions of every browser).
+The `build.target` option in `vite.config.ts` controls what browsers our compiled JavaScript supports. Vite uses this
+target to decide which language features have to be transformed and which can be emitted as they are.
 
-Browserslist takes this description and creates the list of browsers and browser versions that must be supported. To
-see this list yourself, run the following command:
-
-`npx browserslist`
-
-Based on the features these browsers support and do not support, `babel` will determine exactly how to compile our
-ES files.
+The browsers Matomo officially supports are listed separately in `core/SupportedBrowser.php`.
 
 **Polyfills**
 
-Some advanced ES features need polyfills in order to be available in older browsers. These polyfills unfortunately 
-cannot be automatically detected using babel, since we do not know exactly what features every plugin developer will want to
+Some advanced ES features need polyfills in order to be available in older browsers. These polyfills unfortunately
+cannot be detected automatically, since we do not know exactly what features every plugin developer will want to
 use.
 
 So instead we allow a specific set of polyfills to be included and disallow all others. We don't include every possible
@@ -126,33 +114,26 @@ to use this command and only when adding or removing polyfills.
 
 ### Updating Browser Support
 
-browserslist uses an npm package to determine the usage statistics of browsers. As long as it doesn't change, the
-list of minimum supported browsers Matomo supports will stay the same. browserslist is in turn installed as a dependency of @vue/cli-service.
+The compile target is set explicitly with the `build.target` option in `vite.config.ts` (and in
+`plugins/CoreVue/polyfills/vite.config.ts` for the polyfill project).
 
-When it's time to update the minimum supported browser versions, which happens before every major release, all
-that's needed is to upgrade the @vue/cli-service package to the latest version. Then, based on the `npx browserslist`
-output & some manual testing to double check, change the versions in core/SupportedBrowser.php.
+When it's time to update the minimum supported browser versions, which happens before every major release, raise
+`build.target` in both files and, after some manual testing to double check, change the versions in
+`core/SupportedBrowser.php`.
 
-### Async components and chunking
+### Async components and dynamic imports
 
 A note concerning [async components](https://v3.vuejs.org/guide/migration/async-components.html#introduction) in Vue:
-Vue allows developers to define components but not include them in the final bundle, instead loading them dynamically
-via a network request. This is done via the magic `import()` function. This section describes how this is done, so it
-is not so magical.
+Vue allows developers to define components that are loaded lazily via the
+[import()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) function.
 
-[import()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) is an advanced ES
-feature that dynamically loads an ES module over a network, returning a promise that resolves to the ES module object.
-Older browsers do not support this natively, so it is polyfilled by webpack.
+Plugin Vue libraries are built as a single UMD bundle, and UMD has no mechanism for loading additional chunks at
+runtime. Matomo's `vite.config.ts` therefore sets `inlineDynamicImports: true`: anything reached through an `import()`
+call is inlined into the plugin's one `<Plugin>.umd.min.js` file rather than emitted as a separate chunk.
 
-When webpack processes a file to create a bundle, it will notice these `import()` calls and handle them. First,
-it creates a separate bundle (called a **chunk**) for the ES module that is imported. This is outputted as a file like,
-`MyPlugin.umd.1.js`. Then, the `import()` call is replaced with a call to a function provided by webpack, which creates
-a `<script>` element to dynamically load the JavaScript chunk file.
-
-All of this happens transparently to the developer.
-
-_Note: these files, unlike all other JavaScript assets in Matomo, cannot be requested with our cache buster as the
-URL used to load them is, more or less, hardcoded by Webpack._
+The practical consequence is that an async component still works, but it is **not** a separate network request and
+does not reduce the size of the bundle. No extra chunk files are produced, so every asset a plugin ships goes through
+Matomo's normal cache buster.
 
 ### Discovering UMD files
 

--- a/docs/6.x/develop-migration.md
+++ b/docs/6.x/develop-migration.md
@@ -2,6 +2,7 @@
 category: Develop
 title: Migrations
 subGuides:
+  - migrate-matomo-5-to-6
   - migrate-matomo-4-to-5
   - migrate-matomo-3-to-4
   - migrate-piwik-2-to-3

--- a/docs/6.x/in-depth-vue.md
+++ b/docs/6.x/in-depth-vue.md
@@ -7,28 +7,21 @@ This documents advanced and/or uncommon patterns found in Matomo's use of Vue.
 
 ## Vue compilation
 
-Plugin UMD modules are compiled through the Vue CLI tool. This tool uses Webpack and passes the code in a plugin's `vue/`
-directory through the TypeScript compiler, then passes that output through babel to generate the final
-UMD modules.
+Plugin UMD modules are compiled with [Vite](https://vite.dev/), which passes the code in a plugin's `vue/` directory
+through esbuild and, for production builds, minifies it with terser to generate the final UMD modules.
 
-The base configuration for webpack is determined by the Vue CLI tool, but it is customized in the `vue.config.js`
-file. The webpack configuration is also partially where the TypeScript compiler is configured (the main place
-being the tsconfig.json file). Babel is configured primarily in the `babel.config.js` file.
+The configuration lives in `vite.config.ts` in Matomo's root folder, and TypeScript is configured in `tsconfig.json`.
+Each plugin is built on its own: `vue:build` invokes `plugins/CoreVue/scripts/vite-runner.mjs` once per plugin, passing
+the plugin path through the `MATOMO_CURRENT_PLUGIN` environment variable and the artifact to produce through
+`MATOMO_VUE_PHASE`.
 
-During development, TypeScript is configured to do a passthrough transpile only. This means it does very little
-type checking to keep compilation times fast. For the production UMD files however, we turn on full type checking.
-The output of this type information is stored in the `@types` directory, and is only needed and present during
-development.
+The phase controls what is emitted:
 
-### cli-service-proxy.js
+* `min` produces `<Plugin>.umd.min.js` and generates TypeScript declarations into `@types/<Plugin>`;
+* `dev` produces the unminified `<Plugin>.development.umd.js` used by `vue:build --watch`, and skips declarations to
+  keep rebuilds fast.
 
-When compiling .vue files, the Vue CLI service splits out the TypeScript part of the file before feeding it into
-the TypeScript compiler. If errors are detected in this part of the file, the line numbers in the output will
-correspond to the location in the `<script>` element, not to the whole .vue file, which is not especially
-convenient.
-
-The `cli-service-proxy.js` file in the CoreVue plugins invokes the Vue CLI service and corrects these line numbers
-in the TypeScript output. `vue:build` invokes the proxy script.
+The declarations in `@types` are only needed and present during development.
 
 ## Stateful Directives
 

--- a/docs/6.x/tests-github.md
+++ b/docs/6.x/tests-github.md
@@ -20,7 +20,7 @@ Each developer is responsible to keep the build green.
 Plugins can do the same if they include a GitHub action file in their GitHub repository. You can generate this file using the `generate:test-action` console command:
 
 ```
-$ ./console generate:test-action --plugin="MyPlugin" --php-versions="7.2,8.1"
+$ ./console generate:test-action --plugin="MyPlugin" --php-versions="matomo6_min_php,matomo6_max_php"
 ```
 
 The command will automatically detect if you have PHP, Client and/or UI tests in your plugin's directory and create a `.github/workflows/matomo-tests.yml` file that will run them. The tests will be run against the minimal required Matomo version, as defined in your `plugin.json`, as well as against the latest development branch or the latest version your plugin is marked as compatible with.
@@ -36,8 +36,10 @@ You can control how the generated action file behaves, by providing certain opti
 
   * **--php-versions**
 
-    Allows to specify the PHP versions the tests should be run with. You can provide all versions as a comma separated list. e.g. "7.2,8.1" or "7.2,7.4,8.2"
-    
+    Allows to specify the PHP versions the tests should be run with. You can provide all versions as a comma separated list. e.g. "8.1,8.5" or "8.1,8.3,8.5"
+
+    Instead of literal versions you can use the aliases `matomo6_min_php` and `matomo6_max_php` (or `matomo5_min_php` / `matomo5_max_php` for a Matomo 5 branch). These resolve to the centrally managed minimum and maximum PHP versions supported by Matomo tests, so they follow the floor when it moves. The alias table lives in `scripts/bash/resolve_php_version.sh` of the [github-action-tests](https://github.com/matomo-org/github-action-tests) repository.
+
     PHP tests will automatically run against all versions, while UI tests will always be run on the first version provided in the list. 
 
     We recommend to run UI tests on the minimal require PHP version of your plugin (or Matomo) to ensure everything works.

--- a/docs/6.x/vue-getting-started.md
+++ b/docs/6.x/vue-getting-started.md
@@ -308,7 +308,7 @@ If you want to use npm packages that are not installed by Matomo by default, it 
 your plugin's frontend. To use other npm packages, simply run `npm install` or `yarn add` in the plugin directory.
 
 This will install the dependency in a new node_modules folder in the root of your plugin, eg, `plugins/MyPlugin/node_modules`.
-You can then import it as normal, webpack will resolve it correctly when looking for it.
+You can then import it as normal, Vite will resolve it correctly when looking for it.
 
 If you also want to include typings, then you'll have to provide your own tsconfig.json file as well. It should look
 something like:

--- a/docs/6.x/working-with-piwiks-ui.md
+++ b/docs/6.x/working-with-piwiks-ui.md
@@ -69,7 +69,7 @@ This way JavaScript files won't be merged and you can debug the original JavaScr
 Since version 4.5.0 it is possible to create components for the UI using Vue and TypeScript (though note that you do not have to use both;
 you can use Vue with ESnext (the most advanced version of EcmaScript) or just write plain TypeScript without using Vue).
 
-Vue and TypeScript files are processed via webpack using the Vue CLI service, which is configured globally in Matomo. To take advantage of
+Vue and TypeScript files are processed with Vite, which is configured globally in Matomo. To take advantage of
 this, create `vue` and `vue/src` subfolders in your plugin. Then add your code (TypeScript, ES, Vue) to the `src` subfolder. Make sure to
 add an `index.ts` or `index.js` file to the subfolder and export everything you'd like to be programmatically accessible in the browser
 (for example, by other plugins).
@@ -88,8 +88,8 @@ automatically detect if one is there and use it (if the plugin is activated).
 
 **eslint**
 
-The Vue CLI is configured to run ESlint on files while building UMDs. If ESlint finds a style problem based on one of the
-rules we configure, it will be printed out in the output of `vue:build`. Sometimes the actual problem or way to fix it
+ESLint is not run as part of `vue:build`. Run it separately with `npm run eslint`. If ESLint finds a style problem based
+on one of the rules we configure, it will be printed out in the output. Sometimes the actual problem or way to fix it
 is not clear from the error message.
 
 The easiest thing to do in this situation is to search for the rule name in a search engine. Each rule has associated
@@ -188,9 +188,9 @@ For example:
 Below are some solutions to common problems that may occur during development:
 
 * If working on Vue code and `vue:build --watch` is running but the JavaScript isn't being built properly, try restarting the command with the
-  `--clear-webpack-cache` flag, which will clear the webpack cache before watching again and can solve some problems.
-* If working on frontend unit tests that use Jest and you are seeing strange errors, clearing Jest's cache can sometimes help. To do this,
-  run the `npm test -- --clearCache` command.
+  `--clear-cache` flag, which will clear Vite's cache in `node_modules/.vite` before watching again and can solve some problems.
+* If working on frontend unit tests and you are seeing strange errors, the same Vite cache can be at fault. Remove
+  `node_modules/.vite` and run the tests again.
 
 ## Learn more
 

--- a/docs/migrate-matomo-5-to-6.md
+++ b/docs/migrate-matomo-5-to-6.md
@@ -1,0 +1,210 @@
+---
+category: Develop
+---
+# Migrate Plugin from Matomo 5.X to Matomo 6
+
+This migration guide covers the changes required in order to make a plugin compatible with Matomo 6.
+A list of all changes in Matomo 6 can be found in the [Changelog](/changelog).
+
+## Create a new branch
+
+We recommend creating a new branch for your plugin that supports Matomo 6. For example `6.x-dev`. This way you will be able to make changes to your plugin for Matomo 5 and Matomo 6 and release independent versions for each of them. You can still publish updates to your plugin that supports Matomo 5 once you have published an update for a version that supports Matomo 6.
+
+## Adjust the required Matomo version
+
+For your plugin to be executed in Matomo 6 you first need to show it is compatible with Matomo 6 in your `plugin.json` file:
+
+* specify that your plugin requires Matomo 6 (the requirement for Matomo 5 used to be e.g. `"matomo": ">=5.0.0-b1,<6.0.0-b1"`).
+* we also recommend increasing your plugin's major version number e.g. from `5.1.9` to `6.0.0`.
+
+The `plugin.json` would look like this:
+
+```json
+   "version": "6.0.0",
+   "require": {
+        "matomo": ">=6.0.0-b1,<7.0.0-b1"
+    },
+```
+
+The `-b1` suffix on the lower bound matters: a plain `>=6.0.0` sorts above `6.0.0-b1`, so your plugin would be disabled against a Matomo 6 beta or release candidate.
+
+It's not allowed to support multiple major Matomo versions such as Matomo 5 and Matomo 6: `"matomo": ">=5.0.0-b1,<7.0.0-b1"`. In this case you would receive an error email and the release would not be published.
+
+## Required PHP and database versions
+
+Matomo 6 raises the minimum requirements:
+
+* **PHP 8.1.0** (was 7.2.5)
+* **MySQL 8.0** or **MariaDB 10.6** (was 5.5)
+
+If your plugin declares its own `php` requirement in `plugin.json` or `composer.json`, raise it to at least `8.1.0`. Support for TiDB has been dropped.
+
+## Removed PHP APIs
+
+| Removed | Replacement |
+|---|---|
+| `Piwik\Archive::getBlob()` | one of the `Piwik\Archive::getDataTable*()` methods |
+| `Piwik\Archive::clearStaticCache()` | none — it was already a no-op |
+| `Piwik\ArchiveProcessor\Parameters::setIsPartialArchive()` | none — remove the call, see below |
+| `Piwik\Db\Adapter::getDefaultPortForAdapter()` | `Piwik\Db\Schema::getDefaultPortForSchema()` |
+| `Piwik\Db\AdapterInterface::getDefaultPort()` and its `Mysqli` / `Pdo\Mysql` implementations | `Piwik\Db\Schema::getDefaultPortForSchema()` |
+| `Piwik\Url::saveCORSHostnameInConfig()` | none — it was no longer in use |
+| `Piwik\Plugin\Report::getThirdLeveltableDimension()` | `Piwik\Plugin\Report::getNthLevelTableDimension(2)` |
+| `Piwik\Db::optimizeTables()` | `Piwik\Db\Schema::getInstance()->optimizeTables()` |
+| `Piwik\Db::isOptimizeInnoDBSupported()` | `Piwik\Db\Schema::getInstance()->isOptimizeInnoDBSupported()` |
+| `Piwik\Db\TransactionLevel::setUncommitted()` | `Piwik\Db\TransactionLevel::setTransactionLevelForNonLockingReads()` |
+| `Piwik\API\Request::isTokenAuthProvidedSecurely()` | none |
+| `Piwik\Plugins\Overlay\API::getExcludedQueryParameters()` | the `SitesManager.getExcludedQueryParameters` API method |
+
+Note that `getDefaultPort()` also exists as an instance method on `Piwik\Db\SchemaInterface`, which is **not** removed. Check the receiver before changing a call.
+
+An `Archiver` that marked its archive as partial no longer needs to do anything: `Parameters::isPartialArchive()` is now derived from the requested report, so the `setIsPartialArchive(true)` call (usually in the archiver's constructor) should simply be deleted. See [Archiving](/guides/archiving#for-plugins-supporting-partial-archives).
+
+### The SEO plugin has been removed
+
+The whole `SEO` plugin is gone, including its widget, the `SEO.getRank` API method and `Piwik\Plugins\SEO\*` classes. Matomo 6 deactivates and uninstalls it on upgrade. If your plugin referenced it, that reference has to be removed.
+
+### TrackingSpamPrevention is now bundled
+
+`TrackingSpamPrevention` ships with core, is activated by default and can no longer be uninstalled. It is no longer distributed on the Marketplace, and `Piwik\Plugin\Manager::isPluginBundledWithCore('TrackingSpamPrevention')` now returns `true`.
+
+## Removed HTTP API methods
+
+| Removed | Replacement |
+|---|---|
+| `API.getSettings` | none. Integrations reading key/value pairs over the REST API must move to another mechanism; the `[APISettings]` section of `config/global.ini.php` is gone and any entries in a local `config.ini.php` become inert |
+| `SitesManager.setGlobalExcludedQueryParameters` | `SitesManager.setGlobalQueryParamExclusion` |
+| `Overlay.getExcludedQueryParameters` | `SitesManager.getExcludedQueryParameters` |
+| `SEO.getRank` | none |
+
+Remember to search your templates, JavaScript, tests, fixtures and expected files, not just your PHP.
+
+## Removed global functions
+
+The polyfills in `libs/upgradephp/upgrade.php` have been removed, as every supported PHP version provides them natively.
+
+| Removed | Replacement |
+|---|---|
+| `_glob()` | native `glob()`. It returns `false` on error, so callers expecting an array need `glob(…) ?: []` |
+| `safe_serialize()`, `_safe_serialize()` | native `serialize()` |
+| `_parse_ini_file()` | `Piwik\Config`, or `Matomo\Ini\IniReader` for other INI files |
+| the fallbacks for `mysqli_set_charset()`, `file_get_contents()`, `utf8_encode()`, `utf8_decode()`, `fnmatch()`, the `Error` class and `PHP_INT_SIZE` / `PHP_INT_MAX` | the native functions and constants |
+| the `gzopen()` alias to `gzopen64()` | none — `Piwik\Unzip` falls back to `PclZip` |
+
+`safe_unserialize()` is kept, but it is stricter than native `unserialize()`: it rejects `R:` reference tokens and reads a resource back as the integer `0`. Swapping `safe_serialize()` for `serialize()` is therefore only a drop-in replacement for values that contain no objects, references or resources.
+
+`glob()`, `fnmatch()` and `file_get_contents()` also moved from the recommended to the **required** functions in the system check. Matomo now refuses to start when one of them is listed in the `disable_functions` php.ini directive instead of emulating it.
+
+## Removed console commands and scripts
+
+The development console commands `git:commit`, `git:pull` and `git:push` have been removed. Use `git` directly.
+
+The archiving script `./misc/cron/archive.sh` has been removed. Use the `core:archive` console command instead.
+
+## Interface changes
+
+* **`Piwik\Log\LoggerInterface`** follows psr/log 3, so `log()`, `debug()`, `info()`, `notice()`, `warning()`, `error()`, `critical()`, `alert()` and `emergency()` all require a `: void` return type. Plugins that obtain the logger through dependency injection or extend `Piwik\Log\Logger` are not affected.
+
+## Dependency upgrades
+
+Several bundled libraries received a major upgrade. These surface as fatal errors rather than deprecation notices, so they are worth checking even if your plugin looks unaffected.
+
+* **Monolog 1 → 3**: every custom handler, formatter and processor now receives a `Monolog\LogRecord` instead of `array $record`, and records are immutable. `protected function write(array $record)` becomes `protected function write(LogRecord $record): void`, and mutating a record becomes `return $record->with(message: $new);`. Core's handlers under `plugins/Monolog/` are the reference implementations.
+* **PHP-DI 6 → 7**: `Piwik\Container\Container::get()`, `make()` and `injectOn()` gained native types, so an overriding class must match them. Annotation-based injection no longer exists — `@Inject` docblocks must become explicit container configuration or PHP attributes.
+* **Symfony 5.4 → 6.4** (console, event-dispatcher, process, monolog-bridge): `Piwik\Plugin\ConsoleCommand::addOption()` and `addArgument()` return `static` and `getHelper()` returns `mixed`. Only a plugin overriding them is affected.
+* **matomo/matomo-php-tracker 3 → 4**: typed setters. Use `setUserId(null)` instead of `setUserId(false)`, pass a string name to `setCustomVariable()` rather than an array, and declare `: string` on an overridden `getBaseUrl()`.
+* **Others**: `geoip2/geoip2` 2 → 3, `matomo/decompress` 2 → 3, `psr/log` 1 → 3, `wikimedia/less.php` 3 → 5, `twig/twig` now `^3.11.3`. For tests, PHPUnit 8.5 → 9 (`assertRegExp()` becomes `assertMatchesRegularExpression()`) and PHPStan 1.12 → 2.
+
+## Controllers returning JSON
+
+Controller actions that return JSON should now carry the `#[Piwik\Http\JsonResponse]` attribute and declare a `string` return type:
+
+```php
+use Piwik\Http\JsonResponse;
+
+#[JsonResponse]
+public function myControllerMethod(): string
+{
+    return json_encode($result);
+}
+```
+
+An action using the attribute must return the JSON string, must not send the `Content-Type` header itself, and must not emit output or call `exit`/`die` before returning.
+
+**The attribute is not inherited.** If your plugin extends a core controller and overrides an action that core has annotated, you must re-declare `#[JsonResponse]` and declare a compatible `string` return type. Affected core actions include `Dashboard::getAllDashboards()` and `getDashboardLayout()`, `CoreHome::markNotificationAsRead()`, and several in `SitesManager`, `Goals`, `CoreAdminHome`, `Marketplace`, `GeoIp2`, `CoreUpdater` and `MobileMessaging`.
+
+See [Controllers](/guides/controllers#using-controller-methods-as-api-methods) for details.
+
+## Vue build moved to Vite
+
+Matomo 6 builds plugin Vue libraries with [Vite](https://vite.dev/) instead of the Vue CLI, and requires **Node 24**. The `vue:build` command is unchanged, but a few things around it are:
+
+* `vue:build` no longer emits the unminified `plugins/<Plugin>/vue/dist/<Plugin>.umd.js`. Only `<Plugin>.umd.min.js` was ever loaded by Matomo. Delete the committed `vue/dist/<Plugin>.umd.js` from your repository and add `/vue/dist/*.umd.js` to your `.gitignore`.
+* ESLint is no longer run as part of `vue:build`. Run `npm run eslint` separately.
+* The `--clear-webpack-cache` option is now `--clear-cache`, and clears `node_modules/.vite`.
+
+The build is stricter about TypeScript than the previous toolchain. `vue:build` exits with status 0 even when it reports TypeScript errors, so read its output. The recurring fixes are:
+
+* type-only re-exports need `export type { X }` rather than `export { X }`;
+* interfaces referenced in emitted declarations must be exported (`interface State` → `export interface State`);
+* explicit coercion where a type is now checked: `translate('X', count)` → `translate('X', String(count))`, `:content-title="i"` → `:content-title="String(i)"`;
+* null guards: `alert.siteName` → `alert.siteName || ''`, `logs?.length < 1` → `(logs?.length || 0) < 1`, `$sanitize(x)` → `$sanitize(x || '')`;
+* typed array props: `type: Array` → `type: Array as PropType<Alert[]>`, plus the `PropType` import;
+* drop `this.` in templates: `:title="this.triggers[id]"` → `:title="triggers[id]"`;
+* drop the `.ts` suffix from import specifiers: `from '../types.ts'` → `from '../types'`.
+
+Some CoreHome exports are now type-only (`SiteRef`, `WidgetType`, `WidgetContainerType`, `GroupedWidgetsType`); importing them as values fails. `tslib` is a new external provided by the CoreVue polyfill.
+
+## Jest replaced with Vitest
+
+Vue component tests now run on [Vitest](https://vitest.dev/). `npm test` is `TZ=UTC vitest run`. In your specs, replace `jest.mock`, `jest.fn` and `jest.spyOn` with `vi.mock`, `vi.fn` and `vi.spyOn`, drop the Jest-only `{ virtual: true }` mock option, and replace the require-after-mock pattern with an ESM import using `vi.hoisted`.
+
+## Theming and Less changes
+
+Registering a removed stylesheet in `getStylesheetFiles()` breaks stylesheet merging with `The ui asset with 'href' = … is not readable`, so check these first:
+
+* `plugins/Morpheus/stylesheets/base/mode-colors.less` has been removed together with `@color-mode-black` and `@color-mode-white`. Use the `.inDarkMode()` mixin from `base/mixins.less` or a `@theme-color-*` variable.
+* `plugins/Login/stylesheets/variables.less` has been removed together with `@login-section-background`.
+
+Removed Less variables:
+
+* the `Piwik`-era aliases `@color-black-piwik`, `@color-blue-piwik`, `@color-red-piwik` and `@color-green-piwik` — use the `@color-*-matomo` equivalents;
+* the third-party brand colours `@color-orange-brand` (`#f57c00`), `@color-green-brandSocial` (`#009874`), `@color-blue-brandSocial` (`#3b5998`), `@color-blue-brandSocialLight` (`#1c87bd`) and `@color-blue-brandSocialVeryLight` (`#00aced`) — use the literal value;
+* the unused tokens `@color-gray-light`, `@color-gray-bright`, `@color-gray-400`, `@color-jetstream`, `@color-silver-l14`, `@color-silver-l50`, `@color-silver-l70` and `@color-silver-l98`.
+
+Variables that were only used inside a single stylesheet have been inlined or renamed to private `@_`-prefixed names and are no longer visible to other stylesheets: `@top-menu-nav-color`, the four `@color-period-selector*`, the eight `@add-widget-*`, and `@calendarHeaderBackground`, `@calendarHeaderColor`, `@calendarCurrentStateHover` and `@calendarBorder`.
+
+**Themes should note** that `@theme-color-new-brand` / `ThemeStyles::$colorNewBrand` has been removed, and its teal is now the value of `@theme-color-brand` / `$colorBrand` — which previously held green. That green moved to the new `@theme-color-success` / `$colorSuccess`, which is deliberately kept independent of the brand colour so success states stay green when a theme overrides the brand. If your theme overrode `colorNewBrand`, move that override to `colorBrand`, **not** to `colorSuccess`. Note that these are `[light, dark]` pairs where `$colorNewBrand` was a plain string; a bare string still works but gives both modes the same colour. A theme reading `themeStyles.getPropertyValue('colorNewBrand')` breaks silently rather than erroring.
+
+Finally, `@theme-color-widget-background` and a group of `@theme-color-menu-contrast-*` and `@theme-color-widget-*` variables are **deprecated** and will be removed in Matomo 7. They keep working in Matomo 6; see the [Changelog](/changelog) for the full list.
+
+## JavaScript changes
+
+* The jQuery UI widget `$.fn.liveWidget` (`piwik.liveWidget`) has been removed together with `plugins/Live/javascripts/live.js`. Use the `Live.AutoRefreshWidget` Vue component.
+
+## Behaviour changes
+
+These do not produce fatal errors, so they typically show up as unexpected results or failing tests.
+
+* **Request parameters are no longer trimmed.** `Piwik\API\Request::getRequestArrayFromString()` used to apply `trim((string) $value)` to every non-array parameter. Whitespace in values such as a `label` or a segment operand is now preserved, and scalars keep their type. As a consequence, a boolean passed through `Piwik\API\Request::processRequest()` no longer arrives as `'1'`/`''`, so a parameter read with `Common::getRequestVar($name, $default, 'string')` or `Request::getStringParameter()` falls back to its default. Pass a string, or read it with `Request::getBoolParameter()`. See [Request parameters](/guides/request-parameters#whitespace-and-types-are-preserved).
+* **`Annotations.add`, `Annotations.save` and `Annotations.delete` now require `Write` permission.** Previously `add` required only `View`, and an annotation's author could modify or delete it with `View`.
+* **`UsersManager.addCapabilities` and `removeCapabilities`** are now gated behind the `enable_users_admin` setting.
+* **Report rows gained `{metric}_percent_of_total` columns.** If you parse CSV or TSV output by column position, this changes the header and column count — pass `percent_of_total=0` to keep the previous output. See [the API reference](/api-reference/reporting-api#optional-api-parameters).
+* **One Click Update is HTTPS-only.** The "retry over HTTP" fallback and the `https` request parameter of the `CoreUpdater.oneClickUpdate` action have been removed, along with the `$https` parameter of `Piwik\Plugins\CoreUpdater\Updater::updatePiwik()` and `getArchiveUrl()`.
+
+## Tests on CI
+
+If you use the GitHub test action, update the PHP versions it runs against. You can use the `matomo6_min_php` and `matomo6_max_php` aliases instead of literal versions so they follow the supported range:
+
+```
+$ ./console generate:test-action --plugin="MyPlugin" --php-versions="matomo6_min_php,matomo6_max_php"
+```
+
+Set `node-version: '24'` on every job that specifies one, and add a database matrix covering MySQL 8.0 and MariaDB 10.6. More details are in [the GitHub tests guide](/guides/tests-github).
+
+## Summary
+
+In this guide we have seen which steps to take to migrate your Matomo plugin to be compatible with our latest Matomo 6.
+If you need further help with converting your plugin to Matomo 6, head over to the [Matomo developers community forums](https://forum.matomo.org/c/plugins-platform).
+
+Once you've adjusted your plugin, don't forget to release a new version!

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -124,7 +124,7 @@ To be ready for the next step, the first beta release of core, we need to:
 * Follow steps as described in [README.md](https://github.com/matomo-org/developer-documentation/#how-to-add-docs-for-a-new-matomo-version)
 * Replace all mentions of eg. `5.x-dev` by `6.x-dev` in the docs in `docs/*.md` and `docs/6.x/*.md` (for example [this page](https://github.com/matomo-org/developer-documentation/pull/233/files)). The files in `docs/5.x` should remain unchanged.
 * Document new APIs if there are any
-* Create the new migration guide for plugins similar to [this migration guide](https://developer.matomo.org/guides/migrate-matomo-3-to-4). We create this guide even if there are no breaking changes for plugins.
+* Create the new migration guide for plugins similar to [this migration guide](https://developer.matomo.org/guides/migrate-matomo-5-to-6). We create this guide even if there are no breaking changes for plugins.
 * Remove docs from the previous version. For example, if we are currently on Matomo 4 and are starting to work on Matomo 5, and we are still showing docs for Matomo 3, then we edit [config/app.php](https://github.com/matomo-org/developer-documentation/blob/live/app/config/app.php#L13) to remove the docs for Matomo 3 from the UI assuming Matomo 3 was released more than 12 months ago. We keep the docs for at least 12 months as then the LTS expires (see bottom of this page).
 
 ### When releasing a first beta


### PR DESCRIPTION
5 files, +63/-87. Every claim checked against `6.x-dev` source, not the changelog.

- **asset-pipeline.md**: Vue CLI/webpack/babel tool list replaced with Vite + esbuild/terser; `vue:build` now invokes `plugins/CoreVue/scripts/vite-runner.mjs` once per plugin (`MATOMO_CURRENT_PLUGIN` / `MATOMO_VUE_PHASE`). Also corrected two things the plan did not anticipate:
  - **browserslist no longer drives the build.** It is referenced by neither `package.json` nor `vite.config.ts`; the target is a literal `build.target: 'es2015'`. The "Updating Browser Support" section told you to upgrade `@vue/cli-service` and run `npx browserslist`, which does nothing now.
  - **No chunks are emitted.** `vite.config.ts` sets `inlineDynamicImports: true`, so async components are inlined into the single UMD. The old section described `MyPlugin.umd.1.js` chunk files and a cache-buster caveat that no longer exist.
- **in-depth-vue.md**: dropped the `cli-service-proxy.js` section (file deleted) and described the two build phases instead.
- **working-with-piwiks-ui.md**: ESLint is **not** run by `vue:build` any more — `Build.php` has no lint step; use `npm run eslint`. `--clear-webpack-cache` is now `--clear-cache` and clears `node_modules/.vite`. Jest cache advice replaced (Vitest has no `--clearCache`).
- **tests-github.md**: `--php-versions` examples 7.2 → 8.1/8.5, plus the `matomo6_min_php`/`matomo6_max_php` aliases (verified in `resolve_php_version.sh`: 8.1 and 8.5).

**Two catalogue claims turned out to be stale and were deliberately not written in:**
- "Add `.vue` to SFC imports" — `vite.config.ts` sets `resolve.extensions` including `.vue`, so extensionless imports still resolve.
- "`--runInBand` → `--no-file-parallelism`, `--verbose` → `--reporter=verbose`" — those are vitest's own flags. `tests:run-vue` still exposes `--run-in-band` and `--verbose` and wraps them.

Not changed: `vue-troubleshooting.md` (generic TypeScript advice, still valid) and `tests.md` (one generic "Client tests" line).

**Verification caveat:** I could not execute `vue:build`. It needs Node 24 (this machine has 22) plus `npm install` and a configured Matomo. Everything above was verified by reading `vite.config.ts`, `vite-runner.mjs`, `Build.php`, `BuildPolyfill.php` and `TestsRunVue.php` on `6.x-dev`. A run-through on a real 6.x dev environment would be worth doing before merge.