### PR TITLE
Serve 6.x as the latest documentation version

### DIFF
--- a/app/config/app.php
+++ b/app/config/app.php
@@ -14,7 +14,7 @@ if (! defined('MIN_PIWIK_DOCS_VERSION')) {
 }
 
 if (! defined('LATEST_PIWIK_DOCS_VERSION')) {
-    define('LATEST_PIWIK_DOCS_VERSION', 5);
+    define('LATEST_PIWIK_DOCS_VERSION', 6);
 }
 
 if (! defined('DOCS_DOMAIN')) {


### PR DESCRIPTION
One line: `LATEST_PIWIK_DOCS_VERSION` 5 → 6. This is the go-live switch for the whole stack, isolated so it reverts cleanly.

Verified by running the site locally (`php -S` with a router mimicking the .htaccess rewrite):

| Check | Result |
|---|---|
| Version switcher | Matomo 4.X, 5.X, 6.X |
| `/guides/migrate-matomo-5-to-6` | 200 |
| 6.x Migrations submenu | 5-to-6 first, then 4-to-5, 3-to-4, 2-to-3 |
| 5.x / 4.x submenus | unchanged (3 and 2 entries) |
| `/changelog` | renders the **Matomo 6.0.0** section (6.x-dev fetch works) |
| Images on a 6.x guide | resolve to `/img/6.x/…` and serve 200; 5.x still resolves to `/img/5.x/…` |
| `/api-reference/classes`, `/data/documents` | 200 — `docs/6.x/generated/Index.md` is readable |
| `/api-reference/Piwik/Http/SecurityHeaders` | 200 (new 6.0 class from the regenerated tree) |
| New guide in search index | present |

`MIN_PIWIK_DOCS_VERSION` deliberately left at 4; dropping `docs/4.x` is a separate change.

Note: `phpunit.xml.dist` could not be run — `app/composer.json` has an empty `require-dev` and PHPUnit is not installed by any project dependency. Pre-existing, unrelated to this stack.