### PR TITLE
Use Sami build that supports PHP 8 union types

### DIFF
--- a/generator/composer.json
+++ b/generator/composer.json
@@ -30,8 +30,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
-        "tsteur/sami": "dev-dev-4.x-devphp8-twig-update",
+        "php": ">=8.1.0",
+        "tsteur/sami": "dev-fix-union-and-intersection-types",
         "psr/container": "1.1.2"
     }
 }

--- a/generator/composer.lock
+++ b/generator/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4fc359e455924554e1640f316cf9ab2d",
+    "content-hash": "71f1093276adaedfa5381176195346d9",
     "packages": [
         {
             "name": "blackfire/php-sdk",
@@ -442,12 +442,12 @@
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
                     "dev-main": "3.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -641,8 +641,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -720,8 +720,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -794,8 +794,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -989,11 +989,11 @@
         },
         {
             "name": "tsteur/sami",
-            "version": "dev-dev-4.x-devphp8-twig-update",
+            "version": "dev-fix-union-and-intersection-types",
             "source": {
                 "type": "git",
                 "url": "https://github.com/piwik/Sami",
-                "reference": "dfbee6d6d81180e2bf590022bdd5ae6eb27d403b"
+                "reference": "3292f19a98cf53175891df32a31d44d341af1211"
             },
             "require": {
                 "blackfire/php-sdk": "^1.5.18",
@@ -1040,7 +1040,7 @@
             "keywords": [
                 "phpdoc"
             ],
-            "time": "2024-05-13T20:32:37+00:00"
+            "time": "2026-08-24T19:14:39+00:00"
         },
         {
             "name": "twig/twig",
@@ -1131,7 +1131,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.0"
+        "php": ">=8.1.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"


### PR DESCRIPTION
Bottom of the Matomo 6 docs stack. Must merge **before** #970.

**Why it has to go first.** #970 adds `generateDocs "6.x-dev" "6.x"` to `generate.sh`. Sami cannot cast `UnionType`/`IntersectionType` to string, so parsing aborts, `generate.sh` exits 1, and `generateAndPush.sh` bails **before committing anything** — losing the 5.x regeneration too, not just 6.x.

The trigger is `vendor/matomo/matomo-php-tracker/MatomoTracker.php`, which the generator parses directly: 6.x-dev pins tracker `^4.0` (13 union-typed return signatures), 5.x-dev pins `~3.3.0` (none). That is why this only surfaces for 6.x.

Two changes in `generator/`:
- `tsteur/sami` → `dev-fix-union-and-intersection-types` (matomo-org/Sami#5), lock reference `3292f19`
- `php` `>=5.3.0` → `>=7.2.5`; the old floor was long untrue, php-parser 4 and the Sami fork both need PHP 7

Verified: with this lock, `composer install` in `generator/` checks out `3292f19`, and `php generator/generate.php --branch=6.x-dev --targetname=6.x` completes with exit 0. The output is byte-identical to the tree committed in #971.

⚠️ **Deploy step required.** `generate.sh` runs `composer install` only inside `piwik/` (core's dependencies) — it never reinstalls `generator/vendor`. Merging this PR updates the lock in git but changes nothing on the generation host, so the nightly run would still load the old Sami and still fail. **Run `cd generator && composer install` on the generation host once after merging.** Deliberately not scripted; handled manually.

**Note on the branch dependency:** this intentionally points at an unmerged branch rather than `dev-4.x-devphp8-twig-update`. Keep `fix-union-and-intersection-types` alive — if Sami#5 is later squash-merged and the branch deleted, `3292f19` becomes unreachable and `composer install` here breaks. When Sami#5 does get merged, switch this back to `dev-dev-4.x-devphp8-twig-update` and re-run `composer update tsteur/sami`.

Lock diff note: 12 of the 30 changed lines are cosmetic key reordering inside `thanks` blocks, from a newer composer writing the file.