### PR TITLE
Fix doc generation when switching between 5.x-dev and 6.x-dev

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -16,12 +16,15 @@ function generateDocs {
     git submodule foreach --recursive git reset --hard
     git clean -f -d
     git submodule foreach git clean -f
+    # a submodule working tree blocks checking out a branch that tracks the same path as real
+    # files (TrackingSpamPrevention); git clean can't remove it as the gitlink is tracked
+    git submodule deinit -f --all
     git fetch
     git checkout $1
     branchname=$(git rev-parse --abbrev-ref HEAD)
     if [ "$branchname" != "$1" ]; then
        echo "Not on correct branch"
-      return
+      exit 1
     fi
     sleep 4
     git rev-parse --abbrev-ref HEAD


### PR DESCRIPTION
`TrackingSpamPrevention` is a submodule on `5.x-dev` and in-sourced on `6.x-dev`, so after the 5.x run its working tree blocks `git checkout 6.x-dev`:

```
error: The following untracked working tree files would be overwritten by checkout:
    plugins/TrackingSpamPrevention/AllowListIpRange.php
    ...
```

`git clean` cannot clear it — while on 5.x-dev the gitlink is *tracked*, and clean never touches tracked paths. `git submodule deinit -f --all` is the operation that does, and the existing `submodule update --init --recursive --force` after the checkout repopulates whatever the target branch still registers. Deinit leaves `.git/modules/*` intact, so re-init is a local checkout, not a re-clone.

Verified both directions against a real checkout:
- 5.x-dev → 6.x-dev: checkout succeeds, the 19 in-sourced files land
- 6.x-dev → 5.x-dev: checkout succeeds, submodule update restores it as a submodule

**Second half of the fix: `return` → `exit 1`.** That early return is what made the failure destructive rather than merely annoying:

1. the prologue had already run `rm -rf docs/$2/generated`
2. the checkout failed and `return` ended the function — not an error, so `generate.sh` exited **0**
3. `generateAndPush.sh` saw success, ran `git add docs/*/generated` and its own `git rm $DELETED_FILES`, then committed and pushed

That produced 5f5914d4 — a pure deletion of all 270 files under `docs/6.x/generated` (69,751 lines), which is why the 6.x API reference is currently missing from the site. Exiting non-zero makes `generateAndPush.sh` bail before `git add`, so any future prologue-then-fail stops publishing instead of publishing a wipe.

No restore commit needed — the next successful run regenerates the tree and commits it.